### PR TITLE
Installing horizon-protocol with the right permissions

### DIFF
--- a/net-misc/omnissa-horizon-client/omnissa-horizon-client-2506.ebuild
+++ b/net-misc/omnissa-horizon-client/omnissa-horizon-client-2506.ebuild
@@ -68,7 +68,11 @@ src_install() {
 	doins lib/libpcoip_client.so
 	doins -r lib/omnissa
 	doins -r lib/pcoip
+    insinto /usr/lib64/omnissa/horizon/client                                                                                                                                                                                                                 
+    insopts -m0775                                                                                                                                                                                                                                            
+    doins lib/omnissa/horizon/client/horizon-protocol 
 }
+
 pkg_postinst() {
 	ewarn "This ebuild is not working for me"
 	ewarn "Tried Horizon Blast and PCoIP"


### PR DESCRIPTION
Compared the install to a .deb install on a Ubuntu box and found that the permissions for /usr/lib64/omnissa/horizon/client/horizon-protocol were different.
Don't know if the solution is implemented correctly, but after this change, your ebuild worked for me.